### PR TITLE
Add repo url to pyproject.toml

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 James Hoctor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "textual-bee"
 version = "1.4.0"
 description = "A Spelling Bee game for your terminal!"
+license = "MIT"
 authors = ["torshepherd <tor.aksel.shepherd@gmail.com>"]
 readme = "README.md"
 packages = [{ include = "textual_bee" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "A Spelling Bee game for your terminal!"
 authors = ["torshepherd <tor.aksel.shepherd@gmail.com>"]
 readme = "README.md"
 packages = [{ include = "textual_bee" }]
+repository = "https://github.com/torshepherd/textual-bee"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Hi @torshepherd, I found your project on PyPI because I'm planning to publish my own [package](https://github.com/JEHoctor/spelling-bee) related to NYT Spelling Bee. This update to your `pyproject.toml` should add a link to GitHub from PyPI, next time you upload a package.

Unrelated to this PR, would you consider licensing your code? I would humbly suggest an MIT license if you want to allow others to build on this code.